### PR TITLE
feat: reimplement ttl_cache with no threading lock

### DIFF
--- a/evmspec/data/_cache.py
+++ b/evmspec/data/_cache.py
@@ -26,7 +26,7 @@ def _cache(cache, maxsize, typed, info: bool = False):
 
     key = keys.typedkey if typed else keys.hashkey
     get_params = lambda: {"maxsize": maxsize, "typed": typed}
-    
+
     # `info` param was added in 5.3
     if _CACHETOOLS_VERSION >= (5, 3):
 
@@ -36,9 +36,12 @@ def _cache(cache, maxsize, typed, info: bool = False):
             return wrapper
 
     elif info:
-        raise ValueError("You cannot use the `info` param with cachetools versions < 5.3")
-        
+        raise ValueError(
+            "You cannot use the `info` param with cachetools versions < 5.3"
+        )
+
     else:
+
         def decorator(func):
             wrapper = cached(cache=cache, key=key, lock=None)(func)
             wrapper.cache_parameters = get_params

--- a/evmspec/data/_cache.py
+++ b/evmspec/data/_cache.py
@@ -1,0 +1,28 @@
+from time import monotonic
+from cachetools import cached, keys
+from cachetools.func import TTLCache, _UnboundTTLCache
+
+
+def ttl_cache(maxsize=128, ttl=600, timer=monotonic, typed=False):
+    """Decorator to wrap a function with a memoizing callable that saves
+    up to `maxsize` results based on a Least Recently Used (LRU)
+    algorithm with a per-item time-to-live (TTL) value.
+    """
+    if maxsize is None:
+        return _cache(_UnboundTTLCache(ttl, timer), None, typed)
+    elif callable(maxsize):
+        return _cache(TTLCache(128, ttl, timer), 128, typed)(maxsize)
+    else:
+        return _cache(TTLCache(maxsize, ttl, timer), maxsize, typed)
+
+
+def _cache(cache, maxsize, typed):
+    # reimplement ttl_cache with no RLock for race conditions
+
+    def decorator(func):
+        key = keys.typedkey if typed else keys.hashkey
+        wrapper = cached(cache=cache, key=key, lock=None, info=True)(func)
+        wrapper.cache_parameters = lambda: {"maxsize": maxsize, "typed": typed}
+        return wrapper
+
+    return decorator

--- a/evmspec/data/_main.py
+++ b/evmspec/data/_main.py
@@ -461,30 +461,5 @@ class TransactionHash(HexBytes32):
 class BlockHash(HexBytes32): ...
 
 
-def ttl_cache(maxsize=128, ttl=600, timer=monotonic, typed=False):
-    """Decorator to wrap a function with a memoizing callable that saves
-    up to `maxsize` results based on a Least Recently Used (LRU)
-    algorithm with a per-item time-to-live (TTL) value.
-    """
-    if maxsize is None:
-        return _cache(_UnboundTTLCache(ttl, timer), None, typed)
-    elif callable(maxsize):
-        return _cache(TTLCache(128, ttl, timer), 128, typed)(maxsize)
-    else:
-        return _cache(TTLCache(maxsize, ttl, timer), maxsize, typed)
-
-
-def _cache(cache, maxsize, typed):
-    # reimplement ttl_cache with no RLock for race conditions
-
-    def decorator(func):
-        key = keys.typedkey if typed else keys.hashkey
-        wrapper = cached(cache=cache, key=key, lock=None, info=True)(func)
-        wrapper.cache_parameters = lambda: {"maxsize": maxsize, "typed": typed}
-        return wrapper
-
-    return decorator
-
-
 __str_new__ = str.__new__
 __hb_new__ = HexBytes.__new__

--- a/evmspec/data/_main.py
+++ b/evmspec/data/_main.py
@@ -2,20 +2,19 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
 from functools import cached_property
-from time import monotonic
 from typing import TYPE_CHECKING, Any, Callable, Tuple, Type, TypeVar, Union
 
-from cachetools import keys, cached
-from cachetools.func import _UnboundTTLCache, TTLCache
 from cchecksum import to_checksum_address
 from hexbytes import HexBytes
 from msgspec import Raw, Struct, json
 from typing_extensions import Self
 
+from evmspec.data._cache import ttl_cache
 
 if TYPE_CHECKING:
     from evmspec.structs.log import Log
     from evmspec.structs.receipt import TransactionReceipt
+
 
 _T = TypeVar("_T")
 """A generic type variable."""

--- a/evmspec/data/_main.py
+++ b/evmspec/data/_main.py
@@ -13,8 +13,6 @@ from msgspec import Raw, Struct, json
 from typing_extensions import Self
 
 
-
-
 if TYPE_CHECKING:
     from evmspec.structs.log import Log
     from evmspec.structs.receipt import TransactionReceipt
@@ -474,7 +472,8 @@ def ttl_cache(maxsize=128, ttl=600, timer=monotonic, typed=False):
         return _cache(TTLCache(128, ttl, timer), 128, typed)(maxsize)
     else:
         return _cache(TTLCache(maxsize, ttl, timer), maxsize, typed)
-    
+
+
 def _cache(cache, maxsize, typed):
     # reimplement ttl_cache with no RLock for race conditions
 


### PR DESCRIPTION
we dont care about race conditions when checksumming addresses, the lock adds more friction than value