### PR TITLE
fix: missing field creationMethod in trace.create.Action struct

### DIFF
--- a/evmspec/structs/trace/create.py
+++ b/evmspec/structs/trace/create.py
@@ -141,7 +141,9 @@ class Trace(
         try:
             return _decode_action(self._action)
         except ValidationError as e:
-            logger.error(f"error decoding {json.decode(self._action)} into evmspec.structs.trace.create.Action")
+            logger.error(
+                f"error decoding {json.decode(self._action)} into evmspec.structs.trace.create.Action"
+            )
             raise
 
     result: Result

--- a/evmspec/structs/trace/create.py
+++ b/evmspec/structs/trace/create.py
@@ -2,7 +2,7 @@ from functools import cached_property
 from typing import Callable, ClassVar, Final, Literal, final
 
 from hexbytes import HexBytes
-from msgspec import Raw, field
+from msgspec import UNSET, Raw, field
 from msgspec.json import Decoder
 
 from evmspec.data import Address, _decode_hook
@@ -34,6 +34,9 @@ class Action(
 
     init: HexBytes
     """The init code for the deployed contract."""
+
+    creationMethod: Literal["create", "create2"] = UNSET  # type: ignore [assignment]
+    """The method used to create the contract."""
 
 
 @final

--- a/evmspec/structs/trace/create.py
+++ b/evmspec/structs/trace/create.py
@@ -3,7 +3,7 @@ from logging import getLogger
 from typing import Callable, ClassVar, Final, Literal, final
 
 from hexbytes import HexBytes
-from msgspec import UNSET, Raw, field, json
+from msgspec import UNSET, Raw, ValidationError, field, json
 
 from evmspec.data import Address, _decode_hook
 from evmspec.structs.trace._base import _ActionBase, _FilterTraceBase, _ResultBase


### PR DESCRIPTION
fixes ValidationError: Object contains unknown field `creationMethod`