### PR TITLE
fix(cicd): run installed-package checks outside checkout

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -72,11 +72,11 @@ jobs:
         shell: bash
         run: |
           PYTHON="$(poetry env info --executable)"
+          unset PYTHONPATH
+          cd "$RUNNER_TEMP"
           "$PYTHON" - <<'PY'
           import importlib.machinery
-          import os
 
-          os.chdir(os.environ["RUNNER_TEMP"])
           from evmspec import _new
 
           path = _new.__file__ or ""
@@ -91,12 +91,13 @@ jobs:
           mode: instrumentation
           run: |
             PYTHON="$(poetry env info --executable)"
+            unset PYTHONPATH
+            cd "$RUNNER_TEMP"
             "$PYTHON" - <<'PY'
             import os
             import subprocess
             import sys
 
-            os.chdir(os.environ["RUNNER_TEMP"])
             benchmarks = os.path.join(os.environ["GITHUB_WORKSPACE"], "benchmarks")
             raise SystemExit(
                 subprocess.call(

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -69,11 +69,11 @@ jobs:
         shell: bash
         run: |
           PYTHON="$(poetry env info --executable)"
+          unset PYTHONPATH
+          cd "$RUNNER_TEMP"
           "$PYTHON" - <<'PY'
           import importlib.machinery
-          import os
 
-          os.chdir(os.environ["RUNNER_TEMP"])
           from evmspec import _new
 
           path = _new.__file__ or ""
@@ -89,12 +89,13 @@ jobs:
           ETHERSCAN_TOKEN: ${{ secrets.ETHERSCAN_TOKEN  }}
         run: |
           PYTHON="$(poetry env info --executable)"
+          unset PYTHONPATH
+          cd "$RUNNER_TEMP"
           "$PYTHON" - <<'PY'
           import os
           import subprocess
           import sys
 
-          os.chdir(os.environ["RUNNER_TEMP"])
           tests = os.path.join(os.environ["GITHUB_WORKSPACE"], "tests")
           raise SystemExit(
               subprocess.call([sys.executable, "-m", "pytest", "--import-mode=importlib", tests])


### PR DESCRIPTION
Start Python from the runner temp directory and clear PYTHONPATH before compiled-extension checks and test runs so CI imports the installed wheel instead of the source checkout.